### PR TITLE
Feature/bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 1.0.0
+commit = False
+tag = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 1.0.0
-commit = False
+current_version = 1.1.1
+commit = True
 tag = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 commit = True
 tag = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 aiohttp
 beautifulsoup4
 lxml
+bump2version

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from infoarena.group import InfoarenaGroup
 from pbinfo.group import PbinfoGroup
 from solinfo.group import SolinfoGroup
 import github
+import configparser
 
 class Infobot(discord.Client):
   def __init__(self):
@@ -25,6 +26,9 @@ class Infobot(discord.Client):
     print('Ready')
 
 load_dotenv()
+configReader = configparser.RawConfigParser()
+configReader.read("../.bumpversion.cfg")
+CURRENT_VERSION = configReader.get("bumpversion", "current_version")
 client = Infobot()
 tree = app_commands.CommandTree(client)
 
@@ -33,7 +37,7 @@ async def ajutor(interaction: discord.Interaction):
   contributors = [f'[{contrib[0]}]({contrib[1]})' for contrib in await github.get_contributors()]
 
   embed = dsutil.create_embed('Informații', '[Adaugă pe server](https://discord.com/oauth2/authorize?client_id=1006240882812539043&permissions=2147485696&scope=bot)', [
-    ('Despre', 'Infobot este un discord bot care poate prelucra date de pe [pbinfo](https://www.pbinfo.ro), [solinfo](https://www.solinfo.ro/) și [infoarena](https://www.infoarena.ro). Sursa poate fi găsită pe [github](https://github.com/RolandPetrean/infobot).'),
+    ('Despre', f'Infobot ({CURRENT_VERSION}) este un discord bot care poate prelucra date de pe [pbinfo](https://www.pbinfo.ro), [solinfo](https://www.solinfo.ro/) și [infoarena](https://www.infoarena.ro). Sursa poate fi găsită pe [github](https://github.com/RolandPetrean/infobot).'),
     ('Librării folosite', f'Am folosit [discordpy 2.0](https://github.com/Rapptz/discord.py) și [BeautifulSoup 4](https://pypi.org/project/beautifulsoup4/) pentru parsing.'),
     (f'Contribuitori ({len(contributors)})', ', '.join(contributors))
   ], colour=dsutil.LIGHT_BLUE)


### PR DESCRIPTION
Am adaugat `bump2version` pentru a controla mai usor versiunea proiectului.

Daca se executa in terminal, de exemplu: `bump2version patch` (patch/minor/major), o sa se incrementeze numarul de patch a versiunii actuale (ex: acum: `1.1.2`, dupa: `1.1.3`) si de semenea, o sa se dea commit automat (as set up in the config file).